### PR TITLE
div:contenteditable update range for everytime focus event is triggered

### DIFF
--- a/wdt-emoji-bundle.js
+++ b/wdt-emoji-bundle.js
@@ -653,7 +653,7 @@
       var s = window.getSelection();
       if (!wdtEmojiBundle.ranges[this.dataset.rangeIndex]) {
         wdtEmojiBundle.ranges[this.dataset.rangeIndex] = new Range();
-      } else if (s.rangeCount > 0) {
+      } else {
         s.removeAllRanges();
         s.addRange(wdtEmojiBundle.ranges[this.dataset.rangeIndex]);
       }

--- a/wdt-emoji-bundle.js
+++ b/wdt-emoji-bundle.js
@@ -659,7 +659,7 @@
       }
     });
 
-    addListenerMulti(el, 'mouseup keyup', function () {
+    addListenerMulti(el, 'focus mouseup keyup input', function () {
       wdtEmojiBundle.ranges[this.dataset.rangeIndex] = window.getSelection().getRangeAt(0);
     });
 

--- a/wdt-emoji-bundle.js
+++ b/wdt-emoji-bundle.js
@@ -659,7 +659,7 @@
       }
     });
 
-    addListenerMulti(el, 'focus mouseup keyup input', function () {
+    addListenerMulti(el, 'focus mouseup keyup input blur', function () {
       wdtEmojiBundle.ranges[this.dataset.rangeIndex] = window.getSelection().getRangeAt(0);
     });
 


### PR DESCRIPTION
ref https://github.com/needim/wdt-emoji-bundle/pull/45

@tje3d It does not work in Safari.
In Safari, I guess when `focus` event is triggered, `window.getSelection()` take no range, `window.r
angeCount = 0`, then it can not update range.
```
el.addEventListener('focus', function () {
      var s = window.getSelection();
      if (!wdtEmojiBundle.ranges[this.dataset.rangeIndex]) {
        wdtEmojiBundle.ranges[this.dataset.rangeIndex] = new Range();
      } else if (s.rangeCount > 0) {
        s.removeAllRanges();
        s.addRange(wdtEmojiBundle.ranges[this.dataset.rangeIndex]);
      }
    });
```
So I removed `if (s.rangeCount > 0)`
